### PR TITLE
AEH/fix_gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 node_modules/
+package-lock.json
 
 # Expo
 .expo/


### PR DESCRIPTION
**Changes**
- Added package-lock.json to .gitignore.

**Notes**
- From my understanding this is basically mandatory, and should have been implemented day 1. 
- We don't need to include package-lock in github because package.json creates it.
- Having this file in each commit only increases the size of commits and recently merges. 

@dev-arekusandoru Thoughts?