### PR TITLE
AEH/filter_circle_members

### DIFF
--- a/app/(settings)/circleSettings.js
+++ b/app/(settings)/circleSettings.js
@@ -3,6 +3,7 @@ import {
 	Text,
 	View,
 	Platform,
+	Pressable,
 	Animated,
 	ScrollView,
 	FlatList
@@ -18,6 +19,7 @@ const StyledView = styled(View);
 const StyledText = styled(Text);
 const StyledAnimatedView = styled(Animated.createAnimatedComponent(View));
 const StyledScrollView = styled(ScrollView);
+const StyledPressable = styled(Pressable);
 const StyledModal = styled(Modal);
 const StyledGradient = styled(LinearGradient);
 
@@ -38,6 +40,14 @@ export default function Page() {
 	const toggleSwitch = () => setIsEnabled((previousState) => !previousState);
 	const togglePosition = React.useRef(new Animated.Value(1)).current;
 
+	const filtermembers = () => {
+		const roleOrder = ['own', 'mod', 'mem', 'sus', 'ban'];
+		const sortedData = dummyData.sort((a, b) => {
+			return roleOrder.indexOf(a.role) - roleOrder.indexOf(b.role);
+		});
+		setDummyData([...sortedData]);
+	};
+
 	const Trevor =
 		'https://media.licdn.com/dms/image/C4E03AQEjKbD7qFuQJQ/profile-displayphoto-shrink_200_200/0/1574282480254?e=1701907200&v=beta&t=1BizKLULm5emiKX3xlsRq7twzFTqynOsfTlbRwqNuXI';
 
@@ -49,7 +59,7 @@ export default function Page() {
 		}).start();
 	}, [isEnabled]);
 
-	const dummyData = [
+	const originalOrder = [
 		{
 			key: '1',
 			name: 'Josh Philips',
@@ -61,7 +71,7 @@ export default function Page() {
 			key: '2',
 			name: 'Alex Muresan',
 			username: 'muresanCoder.20',
-			role: 'mod',
+			role: 'mem',
 			img: Trevor
 		},
 		{
@@ -105,8 +115,119 @@ export default function Page() {
 			username: 'ExampleAccount3',
 			role: 'mem',
 			img: Trevor
+		},
+		{
+			key: '9',
+			name: 'Another Account',
+			username: 'ExampleAccount4',
+			role: 'mod',
+			img: Trevor
+		},
+		{
+			key: '10',
+			name: 'Another Account',
+			username: 'ExampleAccount5',
+			role: 'mem',
+			img: Trevor
+		},
+		{
+			key: '11',
+			name: 'Another Account',
+			username: 'ExampleAccount6',
+			role: 'sus',
+			img: Trevor
+		},
+		{
+			key: '12',
+			name: 'Another Account',
+			username: 'ExampleAccount7',
+			role: 'ban',
+			img: Trevor
+		},
+		{
+			key: '13',
+			name: 'Nason Allen',
+			username: 'AllenNasin0987654',
+			role: 'mod',
+			img: Trevor
+		},
+		{
+			key: '14',
+			name: 'Aidan Hubley',
+			username: 'HubleyPraying',
+			role: 'ban',
+			img: Trevor
+		},
+		{
+			key: '15',
+			name: 'Trevor Bunch',
+			username: 'BunchTrevoraccount',
+			role: 'mem',
+			img: Trevor
+		},
+		{
+			key: '16',
+			name: 'Another Account',
+			username: 'ExampleAccount1',
+			role: 'sus',
+			img: Trevor
+		},
+		{
+			key: '17',
+			name: 'Another Account',
+			username: 'ExampleAccount2',
+			role: 'mem',
+			img: Trevor
+		},
+		{
+			key: '18',
+			name: 'Another Account',
+			username: 'ExampleAccount3',
+			role: 'mem',
+			img: Trevor
+		},
+		{
+			key: '19',
+			name: 'Another Account',
+			username: 'ExampleAccount4',
+			role: 'mod',
+			img: Trevor
+		},
+		{
+			key: '20',
+			name: 'Another Account',
+			username: 'ExampleAccount5',
+			role: 'mem',
+			img: Trevor
+		},
+		{
+			key: '21',
+			name: 'Another Account',
+			username: 'ExampleAccount6',
+			role: 'sus',
+			img: Trevor
+		},
+		{
+			key: '22',
+			name: 'Another Account',
+			username: 'ExampleAccount7',
+			role: 'ban',
+			img: Trevor
 		}
 	];
+
+	const [dummyData, setDummyData] = useState([...originalOrder]);
+	const [isSorted, setIsSorted] = useState(false);
+
+	const toggleSortOrder = () => {
+		const roleOrder = ['own', 'mod', 'mem', 'sus', 'ban'];
+		const sortedData = isSorted
+		? [...originalOrder]
+		: [...dummyData].sort((a, b) => roleOrder.indexOf(a.role) - roleOrder.indexOf(b.role));
+
+		setDummyData(sortedData);
+		setIsSorted((prev) => !prev); // Toggle the sorting order
+	};
 
 	return (
 		<StyledView
@@ -150,10 +271,31 @@ export default function Page() {
 								description by clicking into the box and typing.
 							</StyledText>
 						</StyledView>
-						<StyledView className='border-x border-t border-[#6666660d] mt-2 w-full h-[45px] pt-2 bg-grey rounded-t-[20px] items-center justify-center'>
+						<StyledView className='border-x border-t border-[#6666660d] mt-2 w-full h-[50px] py-2 bg-grey rounded-t-[20px] items-center justify-center'>
 							<StyledText className='w-full text-center text-[28px] text-white font-[600]'>
 								Members
 							</StyledText>
+							{/* TODO: functioning refresh button */}
+							<Button
+								btnStyles='absolute left-4 top-3'
+								bgColor='bg-transparent'									
+								height={'h-[30px]'}
+								width={'w-[30px]'}
+								iconSize={30}
+								icon='reload'
+								iconColor='#FFFBFC'
+							/>
+							{/* TODO: Create deeper filtering system, search for specific roles? */}
+							<Button
+								btnStyles='absolute right-4 top-3'
+								bgColor='bg-transparent'									
+								height={'h-[30px]'}
+								width={'w-[30px]'}
+								iconSize={30}
+								icon={isSorted ? 'shuffle' : 'filter-outline'}
+								iconColor='#FFFBFC'
+								press={() => toggleSortOrder()}
+							/>
 						</StyledView>
 					</>
 				}


### PR DESCRIPTION
**Changes**
- Increased size of dummy data (circle members)
- Added 2 buttons to circle members table, refresh button and filter button
- Added filtering logic to allow the members to be grouped by status on filter button press
     - The icon changes from a shuffled icon to a filter bars icon, and back again
     - When toggling back, the members list is reset to the original order

**Notes**
- Needs to be tested on iOS, some absolute padding was used

**YouTrack Link**
- N/A